### PR TITLE
Fix Deployment Issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,5 @@ deployment:
   production:
     branch: master
     commands:
+      - scp deploy/deploy.sh lubot@app.atomaka.com:/home/lubot
       - ssh lubot@app.atomaka.com "bash /home/lubot/deploy.sh"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -26,4 +26,5 @@ sudo docker run -d --restart=always --name lubot \
   -e GOOGLE_API_KEY=$GOOGLE_API_KEY \
   -e LUBOT_MEETUP_API_KEY=$LUBOT_MEETUP_API_KEY \
   -e TZ=$TZ \
+  -e REDIS_URL=$REDIS_URL \
   lansingcodes/lubot


### PR DESCRIPTION
Because we are no longer linking containers, we need to make sure that lubot knows the appropriate `REDIS_URL`.  Let's pass it in through the container.

The second commit updates the deployment process to use the deploy.sh from the repository. This allows us to make changes to the deployment process through the repo.  BUT.  Changes to `deploy.sh` should not be checked in every merge request.