### PR TITLE
Don't reclone the repositry everytime

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -3,12 +3,15 @@
 cd $HOME
 source lubotrc
 
-git clone https://github.com/lansingcodes/lubot.git
+if [ ! -d lubot ]; then
+  git clone https://github.com/lansingcodes/lubot.git
+fi
 
 cd $HOME/lubot
+git fetch origin
+get reset --hard origin/master
+
 sudo docker build -t lansingcodes/lubot .
-cd $HOME
-rm -rf $HOME/lubot
 
 sudo docker rm -f lubot
 sudo docker run -d --restart=always --name lubot \


### PR DESCRIPTION
Cloning and deleting the repository deploy causes the Docker layer installing node packages to repeat every deploy.  If we use

```
git fetch origin
get reset --hard origin/master
```

and maintain the current repo, we should be able to speed up the deployment process.