### PR TITLE
[WIP] Use alpine-nodejs image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node
+FROM smebberson/alpine-nodejs
 
-ENV NODE_VERSION 5.0.0
+ENV NODE_VERSION v5.0.0
 ENV NPM_VERSION 3.3.9
 
 # cache our packages.json
@@ -12,5 +12,3 @@ ADD . /opt/hubot
 WORKDIR /opt/hubot
 
 CMD ["/opt/hubot/bin/hubot", "--adapter", "slack"]
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*


### PR DESCRIPTION
The current Docker container for lubot uses the official node image and runs about 697.8MB.  Alpine linux is a minimalist Linux distribution that is becoming commonly used for Docker containers because of its small footprint.  Updating to using [smebberson/alpine-nodejs](https://github.com/smebberson/docker-alpine/tree/master/alpine-nodejs) drops our disk footprint to about 155.4MB.  Usually, this comes with an improved build time of the container, although I haven't confirmed that yet.

The container builds and runs correctly without including environmental variables, but I'd like to schedule a period to do a full test to make sure we maintain full functionality.