### PR TITLE
Fix timezone issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM smebberson/alpine-nodejs
 ENV NODE_VERSION v5.0.0
 ENV NPM_VERSION 3.3.9
 
+RUN apk add --update tzdata \
+    && rm -rf /var/cache/apk*
+
 # cache our packages.json
 ADD package.json /tmp/
 RUN cd /tmp && npm install


### PR DESCRIPTION
Alpine Linux does not have a timezone package installed by default. This request resolves this by installing `tzdata` (http://wiki.alpinelinux.org/wiki/Setting_the_timezone).  Alternatively, we can set the timezone at container creation time with something like:

```
RUN apk add --update tzdata \
  && echo "America/Detroit" >  /etc/timezone
  && apk del tzdata \
  && rm -rf /var/cache/apk*
```

This has the benefit of keeping the image slightly smaller at the cost of making our Docker container less flexible.  I think this request makes the better trade, but feel free to debate!