### PR TITLE
Attempt to prevent permanent disconnect

### DIFF
--- a/lib/initializers/scheduler.ls
+++ b/lib/initializers/scheduler.ls
@@ -10,3 +10,5 @@ module.exports = (robot) !->
     schedule '*/10 * * * * *', \check-for-upcoming-events
   else
     schedule '0 0 9 * * *', \check-for-upcoming-events
+
+  schedule '0 0 * * * *', \keep-alive

--- a/lib/scheduled-tasks/keep-alive.ls
+++ b/lib/scheduled-tasks/keep-alive.ls
@@ -1,0 +1,4 @@
+const debug-room = \debug
+
+module.exports = (robot) !->
+  robot.message-room debug-room, "Attempting to stay alive"


### PR DESCRIPTION
Somtimes, lubot will enter a state where it will wait to reconnect, but never
reconnect.  In an attempt to avoid that, we can have lubot ping a channel once
per hour.  The thread explaining the issue: 
https://github.com/slackhq/hubot-slack/issues/203