### PR TITLE
Restart Lubot if it is not connected for period

### DIFF
--- a/lib/initializers/watch-for-disconnected.ls
+++ b/lib/initializers/watch-for-disconnected.ls
@@ -1,15 +1,21 @@
 intercept = require 'intercept-stdout'
 
+const wait-time = 20_000
+process.env.LUBOT_DISCONNECT_WAIT_TIME = wait-time
+
 module.exports = (robot) !->
   timer = null
 
-  unhook_intercept = intercept (txt) !->
+  intercept (text) !->
 
-    if txt.match //slack client closed, waiting for reconnect//i
+    if /slack client closed, waiting for reconnect/i.test text
 
-      clearTimeout timer
-      timer := setTimeout (-> throw new Error 'Force restarting due to disconnect'), 60 * 1000
+      timer := set-timeout do
+        !-> throw new Error 'Force restarting due to disconnect'
+        wait-time
+      return
 
-    else if txt.match //slack client now connected//i
+    if /slack client now connected/i.test text
 
-      clearTimeout timer
+      clear-timeout timer
+      return

--- a/lib/initializers/watch-for-disconnected.ls
+++ b/lib/initializers/watch-for-disconnected.ls
@@ -1,0 +1,15 @@
+intercept = require 'intercept-stdout'
+
+module.exports = (robot) !->
+  timer = null
+
+  unhook_intercept = intercept (txt) !->
+
+    if txt.match //slack client closed, waiting for reconnect//i
+
+      clearTimeout timer
+      timer := setTimeout (-> throw new Error 'Force restarting due to disconnect'), 60 * 1000
+
+    else if txt.match //slack client now connected//i
+
+      clearTimeout timer

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^3.4.2",
     "hubot-thank-you": "0.0.3",
+    "intercept-stdout": "^0.1.2",
     "livescript": "^1.4.0",
     "moment": "^2.10.6",
     "prelude-ls": "^1.1.2",

--- a/spec/lib/initializers/watch-for-disconnected-spec.ls
+++ b/spec/lib/initializers/watch-for-disconnected-spec.ls
@@ -1,0 +1,26 @@
+describe 'watch-for-disconnected' !->
+  include-hubot!
+
+  before-each !->
+    require('../../../lib/initializers/mentioned-rooms-referencer') robot
+    jasmine.clock!.install!
+
+  after-each !->
+    jasmine.clock!.uninstall!
+
+  she 'starts a timer when a disconnect is detected', (done) !->
+
+    (expect (->
+      robot.logger.info 'Slack client closed, waiting for reconnect'
+      jasmine.clock!.tick 60 * 1000 + 1 * 1000)).toThrow new Error 'Force restarting due to disconnect'
+
+    done!
+
+  she 'cancels a timer that has been started if the client reconnects', (done) !->
+
+    (expect (->
+      robot.logger.info 'Slack client closed, waiting for reconnect'
+      robot.logger.info 'Slack client now connected'
+      jasmine.clock!.tick 60 * 1000 + 1 * 1000)).not.toThrow!
+
+    done!

--- a/spec/lib/initializers/watch-for-disconnected-spec.ls
+++ b/spec/lib/initializers/watch-for-disconnected-spec.ls
@@ -8,7 +8,14 @@ describe 'watch-for-disconnected' !->
   after-each !->
     jasmine.clock!.uninstall!
 
-  she 'starts a timer when a disconnect is detected', (done) !->
+  she 'should not start a timer without a match', (done) !->
+    (expect (->
+      robot.logger.info 'Some message that we should not trigger on'
+      jasmine.clock!.tick 60 * 1000 + 1 * 1000)).not.toThrow!
+
+    done!
+
+  she 'should start a timer when a disconnect is detected', (done) !->
 
     (expect (->
       robot.logger.info 'Slack client closed, waiting for reconnect'
@@ -16,7 +23,7 @@ describe 'watch-for-disconnected' !->
 
     done!
 
-  she 'cancels a timer that has been started if the client reconnects', (done) !->
+  she 'should cancel a timer that has been started if the client reconnects', (done) !->
 
     (expect (->
       robot.logger.info 'Slack client closed, waiting for reconnect'


### PR DESCRIPTION
Watch stdout for the disconnect notice from hubot.  If the client has not reconnected within 60 seconds, lubot will be forcefully restarted.

Tests still needed.