### PR TITLE
Add Lansing JVM User Group info

### DIFF
--- a/lib/helpers/organizer-for.ls
+++ b/lib/helpers/organizer-for.ls
@@ -8,4 +8,5 @@ module.exports = (group) ->
     'Lansing Tech Demo Night': 'erik.gillespie'
     'Lansing Web Meetup': 'jheezy'
     'Mid-Michigan Agile Group': 'jhershey'
+    'Lansing JVM User Group': 'lucidmachine'
   }[group.name]

--- a/lib/initializers/new-participant-notifier.ls
+++ b/lib/initializers/new-participant-notifier.ls
@@ -5,6 +5,7 @@ welcomer-for = (room) ->
     'ruby': \atomaka
     'javascript': \leo
     'mobile': \leo
+    'java': \lucidmachine
   }[room]
 
 module.exports = (robot) !->

--- a/lib/scheduled-tasks/check-for-upcoming-events.ls
+++ b/lib/scheduled-tasks/check-for-upcoming-events.ls
@@ -20,6 +20,7 @@ const announcement-room-for = (event) ->
     'Lansing Tech Demo Night': 'demo-night'
     'Lansing Web Meetup': 'web-design'
     'Mid-Michigan Agile Group': 'agile'
+    'Lansing JVM User Group': 'java'
   }[event-name]
 
 const is-today = (event) ->


### PR DESCRIPTION
* Designate Slack user 'lucidmachine' as organizer for Meetup group 'Lansing JVM User Group'
* Notify Slack user 'lucidmachine' when Slack users join channel 'java'
* Announce events for Meetup group 'Lansing JVM User Group' in Slack channel 'java'